### PR TITLE
Centralize State Management with StateFlow in Essentials

### DIFF
--- a/app/src/main/java/com/aubynsamuel/clipsync/activities/MainActivity.kt
+++ b/app/src/main/java/com/aubynsamuel/clipsync/activities/MainActivity.kt
@@ -52,15 +52,13 @@ class MainActivity : ComponentActivity() {
             val settingsViewModel = viewModel { SettingsViewModel(settingsPrefs) }
             autoCopyEnabled = settingsViewModel.autoCopy.collectAsStateWithLifecycle().value
             val darkTheme = settingsViewModel.isDarkMode.collectAsStateWithLifecycle().value
-            // Set status bar icons color to match app theme
+
             WindowCompat.getInsetsController(window, window.decorView)
                 .isAppearanceLightStatusBars = !darkTheme
 
             ClipSyncTheme(darkTheme = darkTheme) {
                 Navigation(
-                    startBluetoothService = { selectedDeviceAddresses ->
-                        startBluetoothService(selectedDeviceAddresses)
-                    },
+                    startBluetoothService = { startBluetoothService() },
                     pairedDevices = pairedDevices,
                     refreshPairedDevices = { getPairedDevicesList() },
                     stopBluetoothService = { stopBluetoothService() },
@@ -237,10 +235,9 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    private fun startBluetoothService(selectedDeviceAddresses: Set<String>) {
+    private fun startBluetoothService() {
         checkPermissions()
         val serviceIntent = Intent(this, BluetoothService::class.java).apply {
-            putExtra("SELECTED_DEVICES", selectedDeviceAddresses.toTypedArray())
             putExtra("AUTO_COPY_ENABLED", autoCopyEnabled)
         }
 

--- a/app/src/main/java/com/aubynsamuel/clipsync/activities/MainActivity.kt
+++ b/app/src/main/java/com/aubynsamuel/clipsync/activities/MainActivity.kt
@@ -25,6 +25,7 @@ import androidx.core.view.WindowCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.aubynsamuel.clipsync.bluetooth.BluetoothService
+import com.aubynsamuel.clipsync.core.Essentials
 import com.aubynsamuel.clipsync.core.SettingsPreferences
 import com.aubynsamuel.clipsync.core.showToast
 import com.aubynsamuel.clipsync.ui.navigation.Navigation
@@ -33,7 +34,6 @@ import com.aubynsamuel.clipsync.ui.viewModel.SettingsViewModel
 
 class MainActivity : ComponentActivity() {
     private lateinit var bluetoothAdapter: BluetoothAdapter
-    private var autoCopyEnabled: Boolean = false
     private var pairedDevices by mutableStateOf<Set<BluetoothDevice>>(emptySet())
 
     private var discoveredDevices by mutableStateOf<List<BluetoothDevice>>(emptyList())
@@ -50,8 +50,10 @@ class MainActivity : ComponentActivity() {
         setContent {
             val settingsPrefs = SettingsPreferences(this)
             val settingsViewModel = viewModel { SettingsViewModel(settingsPrefs) }
-            autoCopyEnabled = settingsViewModel.autoCopy.collectAsStateWithLifecycle().value
+            val autoCopyEnabled = settingsViewModel.autoCopy.collectAsStateWithLifecycle().value
             val darkTheme = settingsViewModel.isDarkMode.collectAsStateWithLifecycle().value
+
+            Essentials.updateAutoCopy(autoCopyEnabled)
 
             WindowCompat.getInsetsController(window, window.decorView)
                 .isAppearanceLightStatusBars = !darkTheme
@@ -237,9 +239,7 @@ class MainActivity : ComponentActivity() {
 
     private fun startBluetoothService() {
         checkPermissions()
-        val serviceIntent = Intent(this, BluetoothService::class.java).apply {
-            putExtra("AUTO_COPY_ENABLED", autoCopyEnabled)
-        }
+        val serviceIntent = Intent(this, BluetoothService::class.java)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             startForegroundService(serviceIntent)

--- a/app/src/main/java/com/aubynsamuel/clipsync/bluetooth/BluetoothService.kt
+++ b/app/src/main/java/com/aubynsamuel/clipsync/bluetooth/BluetoothService.kt
@@ -63,17 +63,18 @@ class BluetoothService : Service() {
                 selectedDeviceAddresses = devices
             }
         }
+        serviceScope.launch {
+            Essentials.autoCopy.collect { isEnabled ->
+                autoCopyEnabled = isEnabled
+            }
+        }
         createNotificationChannel(this)
         val bluetoothManager = getSystemService(BLUETOOTH_SERVICE) as BluetoothManager
         bluetoothAdapter = bluetoothManager.adapter
         startForeground(FOREGROUND_NOTIFICATION_ID, createServiceNotification(this))
     }
 
-
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        intent?.getBooleanExtra("AUTO_COPY_ENABLED", true)?.let {
-            autoCopyEnabled = it
-        }
         startBluetoothServer()
         return START_STICKY
     }

--- a/app/src/main/java/com/aubynsamuel/clipsync/bluetooth/BluetoothService.kt
+++ b/app/src/main/java/com/aubynsamuel/clipsync/bluetooth/BluetoothService.kt
@@ -39,7 +39,7 @@ class BluetoothService : Service() {
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private lateinit var bluetoothAdapter: BluetoothAdapter
-    private var selectedDeviceAddresses = arrayOf<String>()
+    private var selectedDeviceAddresses = setOf<String>()
     private var autoCopyEnabled = true
     private var serverSocket: BluetoothServerSocket? = null
     private var receiverThread: Thread? = null
@@ -58,39 +58,28 @@ class BluetoothService : Service() {
     override fun onCreate() {
         super.onCreate()
         serviceScope.launch {
-            Essentials.setBluetoothService(this@BluetoothService)
+            Essentials.setServiceRunning(true)
+            Essentials.selectedDevices.collect { devices ->
+                selectedDeviceAddresses = devices
+            }
         }
         createNotificationChannel(this)
-
         val bluetoothManager = getSystemService(BLUETOOTH_SERVICE) as BluetoothManager
         bluetoothAdapter = bluetoothManager.adapter
-
         startForeground(FOREGROUND_NOTIFICATION_ID, createServiceNotification(this))
     }
 
+
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        intent?.getStringArrayExtra("SELECTED_DEVICES")?.let {
-            selectedDeviceAddresses = it
-        }
         intent?.getBooleanExtra("AUTO_COPY_ENABLED", true)?.let {
             autoCopyEnabled = it
         }
-
         startBluetoothServer()
-
         return START_STICKY
     }
 
     override fun onBind(intent: Intent?): IBinder {
         return binder
-    }
-
-    fun updateSelectedDevices(selectedDevices: Array<String>) {
-        selectedDeviceAddresses = selectedDevices
-    }
-
-    fun toggleAutoCopy(value: Boolean) {
-        autoCopyEnabled = value
     }
 
     private fun startBluetoothServer() {
@@ -205,7 +194,7 @@ class BluetoothService : Service() {
             serverSocket?.close()
             receiverThread?.interrupt()
             serviceScope.launch {
-                Essentials.clean()
+                Essentials.clear()
             }
         } catch (e: IOException) {
             Log.e(TAG, "Error closing server socket", e)

--- a/app/src/main/java/com/aubynsamuel/clipsync/core/ObjectsStore.kt
+++ b/app/src/main/java/com/aubynsamuel/clipsync/core/ObjectsStore.kt
@@ -1,92 +1,36 @@
 package com.aubynsamuel.clipsync.core
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
-import com.aubynsamuel.clipsync.bluetooth.BluetoothService
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * Global service state manager for ClipSync.
  *
- * This singleton manages the lifecycle and state of the BluetoothService,
- * providing thread-safe access to service instances and configuration.
- * While generally considered an anti-pattern, this approach is justified here
- * because:
- * 1. The service needs to persist beyond Activity lifecycle
- * 2. Multiple components need real-time access to service state
- * 3. Avoids the overhead of restarting the service for configuration updates
+ * This singleton manages the session state of the BluetoothService,
+ * providing thread-safe, observable properties.
  */
 object Essentials {
-    private val mutex = Mutex()
+    private val _isServiceRunning = MutableStateFlow(false)
+    val isServiceRunning: StateFlow<Boolean> = _isServiceRunning.asStateFlow()
 
-    @Volatile
-    private var _bluetoothService: BluetoothService? = null
+    private val _selectedDevices = MutableStateFlow<Set<String>>(emptySet())
+    val selectedDevices: StateFlow<Set<String>> = _selectedDevices.asStateFlow()
 
-    private var _isServiceBound by mutableStateOf(false)
+    fun setServiceRunning(isRunning: Boolean) {
+        _isServiceRunning.value = isRunning
+    }
 
-    @Volatile
-    private var _selectedDeviceAddresses: Array<String> = emptyArray()
-
-    /**
-     * Observable state indicating if the service is currently bound and active
-     */
-    val isServiceBound: Boolean
-        get() = _isServiceBound
-
-
-    /**
-     * Observable state indicating if the service is currently bound and active
-     */
-    val bluetoothService: BluetoothService?
-        get() = _bluetoothService
-
-    /**
-     * Currently selected device addresses for clipboard sharing
-     */
-    val selectedDeviceAddresses: Array<String>
-        get() = _selectedDeviceAddresses.copyOf()
-
-    /**
-     * Safely sets the BluetoothService instance
-     */
-    suspend fun setBluetoothService(service: BluetoothService?) {
-        mutex.withLock {
-            _bluetoothService = service
-            _isServiceBound = service != null
-        }
+    fun updateSelectedDevices(devices: Set<String>) {
+        _selectedDevices.value = devices
     }
 
     /**
-     * Updates the selected device addresses for sharing
+     * Safely cleans up all session state.
+     * Should be called when the service is stopped.
      */
-    suspend fun updateSelectedDevices(addresses: Array<String>) {
-        mutex.withLock {
-            _selectedDeviceAddresses = addresses.copyOf()
-            if (isServiceBound)
-                _bluetoothService?.updateSelectedDevices(addresses)
-        }
-    }
-
-    /**
-     * Toggles auto-copy functionality
-     */
-    suspend fun toggleAutoCopy(enabled: Boolean) {
-        mutex.withLock {
-            _bluetoothService?.toggleAutoCopy(enabled)
-        }
-    }
-
-    /**
-     * Safely cleans up all references and state
-     * Should be called when the service is stopped
-     */
-    suspend fun clean() {
-        mutex.withLock {
-            _bluetoothService = null
-            _isServiceBound = false
-            _selectedDeviceAddresses = emptyArray()
-        }
+    fun clear() {
+        _isServiceRunning.value = false
+        _selectedDevices.value = emptySet()
     }
 }

--- a/app/src/main/java/com/aubynsamuel/clipsync/core/ObjectsStore.kt
+++ b/app/src/main/java/com/aubynsamuel/clipsync/core/ObjectsStore.kt
@@ -17,12 +17,19 @@ object Essentials {
     private val _selectedDevices = MutableStateFlow<Set<String>>(emptySet())
     val selectedDevices: StateFlow<Set<String>> = _selectedDevices.asStateFlow()
 
+    private val _autoCopy = MutableStateFlow(true)
+    val autoCopy: StateFlow<Boolean> = _autoCopy.asStateFlow()
+
     fun setServiceRunning(isRunning: Boolean) {
         _isServiceRunning.value = isRunning
     }
 
     fun updateSelectedDevices(devices: Set<String>) {
         _selectedDevices.value = devices
+    }
+
+    fun updateAutoCopy(isEnabled: Boolean) {
+        _autoCopy.value = isEnabled
     }
 
     /**

--- a/app/src/main/java/com/aubynsamuel/clipsync/core/RecentDevicesManager.kt
+++ b/app/src/main/java/com/aubynsamuel/clipsync/core/RecentDevicesManager.kt
@@ -29,7 +29,7 @@ class RecentDevicesManager(context: Context) {
     }
 
     fun add(item: String) {
-        // Remove if exists to move it to end
+        // Remove if it exists to move it to the end
         recentItems.remove(item)
         recentItems.add(item)
 

--- a/app/src/main/java/com/aubynsamuel/clipsync/ui/component/ActionButtons.kt
+++ b/app/src/main/java/com/aubynsamuel/clipsync/ui/component/ActionButtons.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun ActionButtons(
-    startBluetoothService: (Set<String>) -> Unit,
+    startBluetoothService: () -> Unit,
     stopBluetoothService: () -> Unit,
     selectedDeviceAddresses: Set<String>,
     scope: CoroutineScope,
@@ -32,7 +32,7 @@ fun ActionButtons(
             onClick = {
                 if (isServiceBound)
                     stopBluetoothService()
-                else startBluetoothService(selectedDeviceAddresses)
+                else startBluetoothService()
             },
             modifier = Modifier.weight(1f),
             shape = RoundedCornerShape(100.dp),

--- a/app/src/main/java/com/aubynsamuel/clipsync/ui/navigation/Navigation.kt
+++ b/app/src/main/java/com/aubynsamuel/clipsync/ui/navigation/Navigation.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
 
 @Composable
 fun Navigation(
-    startBluetoothService: (Set<String>) -> Unit,
+    startBluetoothService: () -> Unit,
     pairedDevices: Set<BluetoothDevice>,
     refreshPairedDevices: () -> Unit,
     stopBluetoothService: () -> Unit,

--- a/app/src/main/java/com/aubynsamuel/clipsync/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/com/aubynsamuel/clipsync/ui/screen/SettingsScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -35,15 +34,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
-import com.aubynsamuel.clipsync.core.Essentials.isServiceBound
-import com.aubynsamuel.clipsync.core.Essentials.toggleAutoCopy
 import com.aubynsamuel.clipsync.ui.component.AppInfoCard
 import com.aubynsamuel.clipsync.ui.component.SettingItem
 import com.aubynsamuel.clipsync.ui.component.WindowsCompanionCard
 import com.aubynsamuel.clipsync.ui.navigation.Screens
 import com.aubynsamuel.clipsync.ui.navigation.safePopBackStack
 import com.aubynsamuel.clipsync.ui.viewModel.SettingsViewModel
-import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -54,13 +50,6 @@ fun SettingsScreen(
     var showResetDialog by remember { mutableStateOf(false) }
     val autoCopy by settingsViewModel.autoCopy.collectAsStateWithLifecycle()
     val isDarkMode by settingsViewModel.isDarkMode.collectAsStateWithLifecycle()
-
-    LaunchedEffect(autoCopy) {
-        delay(300)
-        if (isServiceBound) {
-            toggleAutoCopy(autoCopy)
-        }
-    }
 
     Scaffold(
         topBar = {

--- a/app/src/main/java/com/aubynsamuel/clipsync/widget/ClipSyncWidget.kt
+++ b/app/src/main/java/com/aubynsamuel/clipsync/widget/ClipSyncWidget.kt
@@ -21,7 +21,6 @@ import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.glance.appwidget.provideContent
 import com.aubynsamuel.clipsync.bluetooth.BluetoothService
-import com.aubynsamuel.clipsync.core.SettingsPreferences
 import com.aubynsamuel.clipsync.widget.ui.ErrorContent
 import com.aubynsamuel.clipsync.widget.ui.WidgetContent
 import kotlinx.coroutines.CoroutineScope
@@ -33,7 +32,6 @@ class ClipSyncWidget : GlanceAppWidget() {
     private var bluetoothEnabled by mutableStateOf(false)
     private var isBluetoothReceiverRegistered = false
     private lateinit var bluetoothAdapter: BluetoothAdapter
-    private var autoCopyEnabled: Boolean = true
 
     private val bluetoothStateReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -120,11 +118,6 @@ class ClipSyncWidget : GlanceAppWidget() {
         }
     }
 
-    private fun fetchAutoCopySetting(context: Context) {
-        val settingsPrefs = SettingsPreferences(context)
-        autoCopyEnabled = settingsPrefs.getAutoCopy()
-    }
-
     private fun registerBluetoothReceiver(context: Context) {
         if (!isBluetoothReceiverRegistered) {
             try {
@@ -183,11 +176,7 @@ class ClipSyncWidget : GlanceAppWidget() {
                 loadPairedDevices(context)
             }
 
-            fetchAutoCopySetting(context)
-
-            val serviceIntent = Intent(context, BluetoothService::class.java).apply {
-                putExtra("AUTO_COPY_ENABLED", autoCopyEnabled)
-            }
+            val serviceIntent = Intent(context, BluetoothService::class.java)
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 context.startForegroundService(serviceIntent)

--- a/app/src/main/java/com/aubynsamuel/clipsync/widget/ClipSyncWidget.kt
+++ b/app/src/main/java/com/aubynsamuel/clipsync/widget/ClipSyncWidget.kt
@@ -103,12 +103,7 @@ class ClipSyncWidget : GlanceAppWidget() {
                     WidgetContent(
                         pairedDevices = pairedDevices,
                         stopBluetoothService = { stopBluetoothService(context) },
-                        startBluetoothService = { devices ->
-                            startBluetoothService(
-                                devices,
-                                context
-                            )
-                        },
+                        startBluetoothService = { startBluetoothService(context) },
                         bluetoothEnabled = bluetoothEnabled,
                         context = context,
                         id = id
@@ -182,7 +177,7 @@ class ClipSyncWidget : GlanceAppWidget() {
         }
     }
 
-    private fun startBluetoothService(selectedDeviceAddresses: Set<String>, context: Context) {
+    private fun startBluetoothService(context: Context) {
         try {
             if (bluetoothEnabled) {
                 loadPairedDevices(context)
@@ -191,7 +186,6 @@ class ClipSyncWidget : GlanceAppWidget() {
             fetchAutoCopySetting(context)
 
             val serviceIntent = Intent(context, BluetoothService::class.java).apply {
-                putExtra("SELECTED_DEVICES", selectedDeviceAddresses.toTypedArray())
                 putExtra("AUTO_COPY_ENABLED", autoCopyEnabled)
             }
 

--- a/app/src/main/java/com/aubynsamuel/clipsync/widget/ClipSyncWidgetReceiver.kt
+++ b/app/src/main/java/com/aubynsamuel/clipsync/widget/ClipSyncWidgetReceiver.kt
@@ -1,34 +1,8 @@
 package com.aubynsamuel.clipsync.widget
 
-import android.content.Context
-import android.content.Intent
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
 
 class ClipSyncWidgetReceiver : GlanceAppWidgetReceiver() {
     override val glanceAppWidget: GlanceAppWidget = ClipSyncWidget()
-
-    override fun onReceive(context: Context, intent: Intent) {
-        try {
-            super.onReceive(context, intent)
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
-    }
-
-    override fun onEnabled(context: Context) {
-        try {
-            super.onEnabled(context)
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
-    }
-
-    override fun onDisabled(context: Context) {
-        try {
-            super.onDisabled(context)
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
-    }
 }

--- a/app/src/main/java/com/aubynsamuel/clipsync/widget/ui/DeviceItem.kt
+++ b/app/src/main/java/com/aubynsamuel/clipsync/widget/ui/DeviceItem.kt
@@ -3,6 +3,7 @@ package com.aubynsamuel.clipsync.widget.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
 import androidx.glance.GlanceModifier
+import androidx.glance.action.Action
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.CheckBox
 import androidx.glance.layout.Alignment
@@ -15,16 +16,16 @@ import androidx.glance.text.Text
 
 @Composable
 fun DeviceItem(
-    onChecked: () -> Unit, checked: Boolean, name: String,
+    onChecked: Action, checked: Boolean, name: String,
 ) {
     Row(
         modifier = GlanceModifier
             .fillMaxWidth()
-            .padding(vertical = 2.dp).clickable { onChecked() },
+            .padding(vertical = 2.dp).clickable(onChecked),
         verticalAlignment = Alignment.CenterVertically
     ) {
 
-        CheckBox(checked = checked, onCheckedChange = { onChecked() })
+        CheckBox(checked = checked, onCheckedChange = onChecked)
 
         Column(
             modifier = GlanceModifier.padding(start = 5.dp),


### PR DESCRIPTION
## Summary

This PR refactors the app’s architecture to centralize shared state management through `StateFlow` in the `Essentials` object, improving consistency and reducing redundancy across the app and service components.

### **Key Changes**

#### **StateFlow Integration**
- Replaced manual state tracking in `ObjectsStore.kt` with `StateFlow` for `isServiceRunning` and `selectedDevices`.
- UI components and widgets now observe these states directly from the `Essentials` object for real-time updates.

#### **BluetoothService Refactor**
- `BluetoothService` now observes `Essentials.selectedDevices` and `Essentials.autoCopy`, eliminating the need to pass extras through Intents.
- Removed outdated `LaunchedEffect` blocks and Intent-based parameters for a cleaner architecture.

#### **Widget & UI Synchronization**
- Updated `MainScreen`, `ActionButtons`, and `WidgetContent` to read from and modify `Essentials` states directly.
- Introduced a `ToggleDeviceCallback` to allow widgets to update the shared device state.
- Simplified `ClipSyncWidgetReceiver` by removing unnecessary error handling.

#### **General Improvements**
- Centralized `autoCopy` handling via `Essentials.updateAutoCopy()` for better control and less boilerplate.
- Removed redundant variables (`autoCopyEnabled`, `isServiceBound`) and lifecycle sync code.

This refactor improves reliability, eliminates race conditions, and ensures all UI and service layers share a consistent, reactive state.
